### PR TITLE
Fix specs and rework database loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
 jobs:
-
   # SQLITE
   sqlite:
     runs-on: ubuntu-latest
@@ -28,7 +27,10 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: [ rails_main, rails_7_0 ]
+            gemfile: rails_main
+
+          - ruby: '2.6'
+            gemfile: rails_7_0
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -66,7 +68,10 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: [ rails_main, rails_7_0 ]
+            gemfile: rails_main
+
+          - ruby: '2.6'
+            gemfile: rails_7_0
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
@@ -119,7 +124,10 @@ jobs:
 
           # Rails 7 requires Ruby 2.7 or higher
           - ruby: '2.6'
-            gemfile: [ rails_main, rails_7_0 ]
+            gemfile: rails_7_0
+
+          - ruby: '2.6'
+            gemfile: rails_main
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true

--- a/awesome_nested_set.gemspec
+++ b/awesome_nested_set.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '>= 4.0.0', '< 7.1'
 
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'combustion', '>= 0.5.2', '< 0.5.5'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'


### PR DESCRIPTION
The older version of combustion used by awesome_nested_set doesn't
appear to be compatible with rails 7, and the latest version of
combustion no longer has an API that lets you pass in a config.

So this commit drops the dependency on combustion and just uses the
rails task for database setup and teardown.